### PR TITLE
[LITO-140] fix: 문제 틀린 횟수가 0일 때 처리

### DIFF
--- a/Django-CF/api/tasks.py
+++ b/Django-CF/api/tasks.py
@@ -127,6 +127,8 @@ class Translator:
                     json_form[self.json_problemId] = problemId+1
                     content[self.json_data].append(json_form)
                     recommend_count += 1
+                else:
+                    skipped.append((problemId, wrong_cnt_matrix[userId][problemId]))
             
             if recommend_count < 3:
                 skipped.sort(key=lambda x: x[1], reverse = True)


### PR DESCRIPTION
## 작업내용
문제 틀린 횟수 0일 때 리스트에 안 담기므로 에러 발생 -> else로 분기 시킨 뒤 append